### PR TITLE
fix: typos in real_agents/adapters/data_model/

### DIFF
--- a/real_agents/adapters/data_model/message.py
+++ b/real_agents/adapters/data_model/message.py
@@ -146,7 +146,7 @@ class MessageDataModel:
 
     @classmethod
     def extract_action_for_llm(cls, text, max_token: int = 500) -> str:
-        """Since Action should be fully inputed into an Agent, so we do not perform truncation here."""
+        """Since Action should be fully inputted into an Agent, so we do not perform truncation here."""
         action_format = ACTION_FORMAT
         cleaned_output = text.strip()
         try:

--- a/real_agents/adapters/data_model/plugin/spec.py
+++ b/real_agents/adapters/data_model/plugin/spec.py
@@ -37,7 +37,7 @@ def process_one_property(name: str, value_dict: Dict[str, Any]) -> str:
     description = value_dict.get("description", None)
     required = value_dict.get("required", None)
 
-    type = value_dict.get("type", "UnkownType")
+    type = value_dict.get("type", "UnknownType")
     value_choices = value_dict.get("enum", [])
 
     ret = (


### PR DESCRIPTION
This pull request fixes typos in Python files under the directory `real_agents/adapters/data_model/`, which includes function definition helper text. I request the repository maintainers to review and merge it. Thanks! :heart: 