### PR TITLE
Update: export mongodb env variables

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -110,6 +110,7 @@ Redis serves as cache, the persistent data will be stored in MongoDB and will be
 export VARIABLE_REGISTER_BACKEND=redis
 export MESSAGE_MEMORY_MANAGER_BACKEND=database
 export JUPYTER_KERNEL_MEMORY_MANAGER_BACKEND=database
+export MONGO_SERVER=127.0.0.1
 ```
 
 </details>

--- a/backend/setup_script.sh
+++ b/backend/setup_script.sh
@@ -53,5 +53,6 @@ echo "Setting up environment variables..."
 export VARIABLE_REGISTER_BACKEND=redis
 export MESSAGE_MEMORY_MANAGER_BACKEND=database
 export JUPYTER_KERNEL_MEMORY_MANAGER_BACKEND=database
+export MONGO_SERVER=127.0.0.1
 
 echo "Deployment complete\!"


### PR DESCRIPTION
Fix mongo environment variables missing problem caused in https://github.com/xlang-ai/OpenAgents/pull/43

Add MONGO_SERVER script in `backend/README.md`, and `backend/setup_script.sh`